### PR TITLE
Add `FileSystem.listDirectory`

### DIFF
--- a/src/FileSystem.gren
+++ b/src/FileSystem.gren
@@ -6,6 +6,7 @@ module FileSystem exposing
     , ReadableFileHandle
     , WriteableFileHandle
     , ReadWriteableFileHandle
+    , DirEntry(..)
     --
     , UnknownFileSystemError(..)
     , AccessError(..)
@@ -27,6 +28,7 @@ module FileSystem exposing
     --
     , makeDirectory
     , listDirectoryContent
+    , listDirectory
     --
     , buildPath
     , normalizePath
@@ -62,7 +64,7 @@ module FileSystem exposing
 
 ## Directories
 
-@docs makeDirectory, listDirectoryContent
+@docs makeDirectory, listDirectoryContent, listDirectory, DirEntry
 
 ##
 
@@ -108,6 +110,21 @@ type.
 type FileHandle readAccess writeAccess
     -- Note: Actual implementation in kernel code
     = FileHandle
+
+
+{-| Represents items in a directory.
+
+Variants for each type of file, holding a `String` with the filename.
+
+As returned by `FileSystem.listDirectory`.
+-}
+type DirEntry
+    = File String
+    | Directory String
+    | Socket String
+    | Symlink String
+    | Device String
+    | Pipe String
 
 
 type ReadPermission = ReadPermission
@@ -288,6 +305,14 @@ given path.
 listDirectoryContent : Permission -> String -> Task AccessError (Array String)
 listDirectoryContent _ path =
     Gren.Kernel.FileSystem.listDirectoryContent path
+
+
+{-| Returns an `Array` of `DirEntry` variants holding names of the files in the
+directory at the given path.
+-}
+listDirectory : Permission -> String -> Task AccessError (Array DirEntry)
+listDirectory _ path =
+    Gren.Kernel.FileSystem.listDirectory path
 
 
 -- PATHS

--- a/src/FileSystem.gren
+++ b/src/FileSystem.gren
@@ -64,7 +64,7 @@ module FileSystem exposing
 
 ## Directories
 
-@docs makeDirectory, listDirectoryContent, listDirectory, DirEntry
+@docs makeDirectory, listDirectoryContent, DirEntry, listDirectory
 
 ##
 

--- a/src/FileSystem.gren
+++ b/src/FileSystem.gren
@@ -112,9 +112,9 @@ type FileHandle readAccess writeAccess
     = FileHandle
 
 
-{-| Represents items in a directory.
+{-| Represents entries in a directory.
 
-Variants for each type of file, holding a `String` with the filename.
+Variants for each type of entry, with a `String` representing the relative path.
 
 As returned by `FileSystem.listDirectory`.
 -}

--- a/src/Gren/Kernel/FileSystem.js
+++ b/src/Gren/Kernel/FileSystem.js
@@ -228,13 +228,13 @@ var _FileSystem_listDirectory = function (path) {
       if (err != null) {
         callback(__Scheduler_fail(_FileSystem_constructAccessError(err)));
       } else {
-        callback(__Scheduler_succeed(content.map(toGrenDirEntry)));
+        callback(__Scheduler_succeed(content.map(_FileSystem_toGrenDirEntry)));
       }
     });
   });
 };
 
-var toGrenDirEntry = function (dirEnt) {
+var _FileSystem_toGrenDirEntry = function (dirEnt) {
   if (dirEnt.isFile()) {
     return __FileSystem_File(dirEnt.name);
   } else if (dirEnt.isDirectory()) {


### PR DESCRIPTION
To get file type info along with the filenames.

Addresses https://github.com/gren-lang/node/issues/3

Went with type variants instead of a record alias because it felt like a better design and nicer for pattern matching, but happy to discuss or change.

Tested with:

```
type Msg
    = GotDirContents (Result AccessError (Array DirEntry))

init : Program.AppInitTask { model : Model, command : Cmd Msg }
init =
    Program.await Node.initialize <| \nodeConfig ->
        Program.await FileSystem.initialize <| \fsPermission ->
            Program.startProgram
                { model = {}
                , command = FileSystem.listDirectory fsPermission "./testdir"
                    |> Task.attempt GotDirContents
                }

update : Msg -> Model -> { model : Model, command : Cmd Msg }
update msg model =
    case msg of
        GotDirContents contents ->
            { model = model
            , command = Stream.sendString model.stdout <|

                {- Set up `./testdir` with:

                    $ touch file
                    $ mkdir dir
                    $ mkfifo pipe
                    $ ln -s file link

                  And the output is:

                    Ok [Directory "dir", File "file", Symlink "link", Pipe "pipe"]

                  To test Device type, listed `/dev` dir.
                  and got `Device "disk0", etc...`

                -}
                Debug.toString contents
            }
```

Tangent: Wondering what it would take and what it might look like to automate functional testing like the above...