### PR TITLE
Use elm syntax highlighting on github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.gren linguist-language=Elm


### PR DESCRIPTION
Not sure if you want this or not, but I think it makes things a little friendlier when viewing source on github, especially examples.