### PR TITLE
Fix crash when using HttpClient with HttpServer

### DIFF
--- a/src/Gren/Kernel/HttpServer.js
+++ b/src/Gren/Kernel/HttpServer.js
@@ -7,11 +7,11 @@ import Platform exposing (sendToApp, sendToSelf)
 
 */
 
-const http = require("http");
+const httpServer = require("http");
 
 var _HttpServer_createServer = F2(function (host, port) {
   return __Scheduler_binding(function (callback) {
-    const server = http.createServer();
+    const server = httpServer.createServer();
     server.on("error", function (e) {
       callback(
         __Scheduler_fail(A2(__HttpServer_ServerError, e.code, e.message))


### PR DESCRIPTION
Both HttpClient and HttpServer create a const called "http", causing a naming conflict in the compiled js when you use both.