### PR TITLE
Add ChildProcess.spawnAsCmd

### DIFF
--- a/src/ChildProcess.gren
+++ b/src/ChildProcess.gren
@@ -1,4 +1,4 @@
-module ChildProcess exposing 
+effect module ChildProcess where { command = MyCmd } exposing 
     ( Permission
     , initialize
     --
@@ -18,6 +18,7 @@ module ChildProcess exposing
     , Connection(..)
     , defaultSpawnOptions
     , spawn
+    , spawnAsCmd
     , spawnWithDefaultOptions
     )
 
@@ -37,7 +38,7 @@ This module allow you to spawn child processes.
 
 ## Spawning processes
 
-@docs SpawnOptions, Connection, defaultSpawnOptions, spawn, spawnWithDefaultOptions
+@docs SpawnOptions, Connection, defaultSpawnOptions, spawn, spawnWithDefaultOptions, spawnAndNotifyOnExit
 -}
 
 
@@ -256,6 +257,28 @@ type alias SpawnOptions =
     }
 
 
+{-| Record expected by spawn kernel call.
+-}
+type alias KernelSpawnConfig =
+    { program : String
+    , arguments : Array String
+    , shell : 
+        { choice : Int
+        , value : String 
+        }
+    , workingDirectory : 
+        { inherit : Bool
+        , override : String
+        }
+    , environmentVariables :
+        { option : Int
+        , value : Dict String String
+        }
+    , runDuration : Int
+    , connection : Int
+    }
+
+
 {-| What relation should the newly spawned process have with the running application?
 
 * `Integrated` means that the spawned process shares the stdin, stdout and stderr streams and that the application will wait for its termination.
@@ -289,70 +312,88 @@ This is mostly helpful for starting long-running processes.
 spawn : Permission -> String -> Array String -> SpawnOptions -> Task x Process.Id
 spawn _ program arguments opts =
     Process.spawn <|
-        Gren.Kernel.ChildProcess.spawn
-            { program = program
-            , arguments = arguments
-            , shell =
-                case opts.shell of
-                    NoShell ->
-                        { choice = 0
-                        , value = ""
-                        }
+        Gren.Kernel.ChildProcess.spawn <|
+            kernelSpawnConfig program arguments opts
 
-                    DefaultShell ->
-                        { choice = 1
-                        , value = ""
-                        }
 
-                    CustomShell value ->
-                        { choice = 2
-                        , value = value
-                        }
-            , workingDirectory =
-                 case opts.workingDirectory of
-                     InheritWorkingDirectory -> 
-                        { inherit = True
-                        , override = ""
-                        }
+{-| Spawn a process with the given name, arguments and options, and let it run in the background.
+When the process completes, trigger the given message with the exit code.
 
-                     SetWorkingDirectory value ->
-                        { inherit = False
-                        , override = value
-                        }
-            , environmentVariables =
-                case opts.environmentVariables of
-                    InheritEnvironmentVariables -> 
-                        { option = 0
-                        , value = Dict.empty
-                        }
-                
-                    MergeWithEnvironmentVariables value ->
-                        { option = 1
-                        , value = value
-                        }
+    spawnAsCmd permission SleepFinished "sleep" [ "2" ] defaultSpawnOptions 
 
-                    ReplaceEnvironmentVariables value ->
-                        { option = 2
-                        , value = value
-                        }
-            , runDuration =
-                case opts.runDuration of
-                    NoLimit ->
-                        0
+-}
+spawnAsCmd : Permission -> (Int -> msg) -> String -> Array String -> SpawnOptions -> Cmd msg
+spawnAsCmd _ toMsg program arguments opts =
+    command <|
+        Spawn toMsg <|
+            kernelSpawnConfig program arguments opts
 
-                    Milliseconds ms -> 
-                        max 0 ms
-            , connection =
-                case opts.connection of
-                    Integrated ->
-                        0
 
-                    Ignored ->
-                        1
+kernelSpawnConfig : String -> Array String -> SpawnOptions -> KernelSpawnConfig
+kernelSpawnConfig program arguments opts =
+    { program = program
+    , arguments = arguments
+    , shell =
+        case opts.shell of
+            NoShell ->
+                { choice = 0
+                , value = ""
+                }
 
-                    Detached ->
-                        2
-            }
+            DefaultShell ->
+                { choice = 1
+                , value = ""
+                }
+
+            CustomShell value ->
+                { choice = 2
+                , value = value
+                }
+    , workingDirectory =
+         case opts.workingDirectory of
+             InheritWorkingDirectory -> 
+                { inherit = True
+                , override = ""
+                }
+
+             SetWorkingDirectory value ->
+                { inherit = False
+                , override = value
+                }
+    , environmentVariables =
+        case opts.environmentVariables of
+            InheritEnvironmentVariables -> 
+                { option = 0
+                , value = Dict.empty
+                }
+        
+            MergeWithEnvironmentVariables value ->
+                { option = 1
+                , value = value
+                }
+
+            ReplaceEnvironmentVariables value ->
+                { option = 2
+                , value = value
+                }
+    , runDuration =
+        case opts.runDuration of
+            NoLimit ->
+                0
+
+            Milliseconds ms -> 
+                max 0 ms
+    , connection =
+        case opts.connection of
+            Integrated ->
+                0
+
+            Ignored ->
+                1
+
+            Detached ->
+                2
+    }
 
 
 {-| Same as [spawn], but with [defaultSpawnOptions](#defaultSpawnOptions) passed in as options.
@@ -360,3 +401,44 @@ spawn _ program arguments opts =
 spawnWithDefaultOptions : Permission -> String -> Array String -> Task x Process.Id
 spawnWithDefaultOptions permission program arguments =
     spawn permission program arguments defaultSpawnOptions
+
+
+-- COMMANDS
+
+
+type MyCmd msg
+    = Spawn (Int -> msg) KernelSpawnConfig
+
+
+cmdMap : (a -> b) -> MyCmd a -> MyCmd b
+cmdMap func cmd =
+    case cmd of
+        Spawn toMsg config ->
+            Spawn (toMsg >> func) config
+
+
+init : Task Never {}
+init =
+    Task.succeed {}
+
+
+onEffects : Platform.Router msg Never -> Array (MyCmd msg) -> {} -> Task Never {}
+onEffects router commands state =
+  case Array.popFirst commands of
+    Nothing ->
+      Task.succeed state
+
+    Just { first, rest } ->
+        case first of
+            Spawn toMsg config ->
+                Gren.Kernel.ChildProcess.spawnAsCmd 
+                    (Platform.sendToApp router << toMsg) 
+                    config
+                        |> Process.spawn
+                        |> Task.andThen 
+                            (\_ -> onEffects router rest {})
+
+
+onSelfMsg : Platform.Router msg Never -> Never -> {} -> Task Never {}
+onSelfMsg _ _ _ =
+    Task.succeed {}

--- a/src/ChildProcess.gren
+++ b/src/ChildProcess.gren
@@ -18,7 +18,7 @@ effect module ChildProcess where { command = MyCmd } exposing
     , Connection(..)
     , defaultSpawnOptions
     , spawn
-    , spawnAsCmd
+    , spawnAndNotifyOnExit
     , spawnWithDefaultOptions
     )
 
@@ -319,11 +319,11 @@ spawn _ program arguments opts =
 {-| Spawn a process with the given name, arguments and options, and let it run in the background.
 When the process completes, trigger the given message with the exit code.
 
-    spawnAsCmd permission SleepFinished "sleep" [ "2" ] defaultSpawnOptions 
+    spawnAndNotifyOnExit permission SleepFinished "sleep" [ "2" ] defaultSpawnOptions 
 
 -}
-spawnAsCmd : Permission -> (Int -> msg) -> String -> Array String -> SpawnOptions -> Cmd msg
-spawnAsCmd _ toMsg program arguments opts =
+spawnAndNotifyOnExit : Permission -> (Int -> msg) -> String -> Array String -> SpawnOptions -> Cmd msg
+spawnAndNotifyOnExit _ toMsg program arguments opts =
     command <|
         Spawn toMsg <|
             kernelSpawnConfig program arguments opts
@@ -431,7 +431,7 @@ onEffects router commands state =
     Just { first, rest } ->
         case first of
             Spawn toMsg config ->
-                Gren.Kernel.ChildProcess.spawnAsCmd 
+                Gren.Kernel.ChildProcess.spawnAndNotifyOnExit 
                     (Platform.sendToApp router << toMsg) 
                     config
                         |> Process.spawn

--- a/src/Gren/Kernel/ChildProcess.js
+++ b/src/Gren/Kernel/ChildProcess.js
@@ -1,8 +1,9 @@
 /*
 
-import Gren.Kernel.Scheduler exposing (binding, succeed, fail)
+import Gren.Kernel.Scheduler exposing (binding, succeed, fail, rawSpawn)
 import Gren.Kernel.Utils exposing (update)
 import Dict exposing (foldl)
+import ChildProcess exposing (FailedRun, SuccessfulRun)
 
 */
 
@@ -69,28 +70,45 @@ var _ChildProcess_run = function (options) {
 
 var _ChildProcess_spawn = function (options) {
   return __Scheduler_binding(function (callback) {
-    var workingDir = options.__$workingDirectory;
-    var env = options.__$environmentVariables;
-    var shell = options.__$shell;
-
-    var subproc = childProcess.spawn(options.__$program, options.__$arguments, {
-      cwd: _ChildProcess_handleCwd(workingDir),
-      env: _ChildProcess_handleEnv(env),
-      timeout: options.__$runDuration,
-      shell: _ChildProcess_handleShell(shell),
-      stdio: options.__$connection === 0 ? "inherit" : "ignore",
-      detached: options.__$connection === 2 && process.platform === "win32",
-    });
-
-    if (options.__$connection === 2) {
-      subproc.unref();
-    }
-
+    var subproc = _ChildProcess_getSubProc(options);
     return function () {
       subproc.kill();
     };
   });
 };
+
+var _ChildProcess_spawnAsCmd = F2(function (sendToApp, options) {
+  return __Scheduler_binding(function (callback) {
+    var subproc = _ChildProcess_getSubProc(options);
+    subproc.on("exit", function (code) {
+      callback(__Scheduler_rawSpawn(sendToApp(code)));
+    });
+    return function () {
+      subproc.kill();
+    };
+  });
+});
+
+function _ChildProcess_getSubProc(options) {
+  var workingDir = options.__$workingDirectory;
+  var env = options.__$environmentVariables;
+  var shell = options.__$shell;
+
+  var subproc = childProcess.spawn(options.__$program, options.__$arguments, {
+    cwd: _ChildProcess_handleCwd(workingDir),
+    env: _ChildProcess_handleEnv(env),
+    timeout: options.__$runDuration,
+    shell: _ChildProcess_handleShell(shell),
+    stdio: options.__$connection === 0 ? "inherit" : "ignore",
+    detached: options.__$connection === 2 && process.platform === "win32",
+  });
+  
+  if (options.__$connection === 2) {
+    subproc.unref();
+  }
+
+  return subproc;
+}
 
 function _ChildProcess_handleCwd(cwd) {
   return cwd.__$inherit ? process.cwd() : cwd.__$override;

--- a/src/Gren/Kernel/ChildProcess.js
+++ b/src/Gren/Kernel/ChildProcess.js
@@ -77,7 +77,7 @@ var _ChildProcess_spawn = function (options) {
   });
 };
 
-var _ChildProcess_spawnAsCmd = F2(function (sendToApp, options) {
+var _ChildProcess_spawnAndNotifyOnExit = F2(function (sendToApp, options) {
   return __Scheduler_binding(function (callback) {
     var subproc = _ChildProcess_getSubProc(options);
     subproc.on("exit", function (code) {


### PR DESCRIPTION
This will let us capture the exit code in the haskell part of the compiler to address https://github.com/gren-lang/compiler/issues/253

This is a stopgap until ChildProcess can be rewritten.