### PR TITLE
Update FileSystem.js

### DIFF
--- a/src/Gren/Kernel/FileSystem.js
+++ b/src/Gren/Kernel/FileSystem.js
@@ -161,7 +161,7 @@ var _FileSystem_writeHelper = function (
       }
 
       if (bytesWritten === length) {
-        callback(__Scheduler_succeed(fd));
+        callback(__Scheduler_succeed(fh));
         return;
       }
 


### PR DESCRIPTION
When using this module, ran into this error:

```
ReferenceError: fd is not defined
    at /Users/joey/Documents/GitHub/homeward/server/app:3198:37
    at FSReqCallback.wrapper [as oncomplete] (node:fs:829:5)
```

Tracking down the error led to this very small typo. Changing `fd` -> `fh` in the generated code seems to fix the error.