### PR TITLE
Fix incoming url parsing in HttpServer.Request

### DIFF
--- a/src/Gren/Kernel/HttpServer.js
+++ b/src/Gren/Kernel/HttpServer.js
@@ -40,12 +40,7 @@ var _HttpServer_addListener = F3(function (server, router, msg) {
       .on("end", function () {
         const buffer = Buffer.concat(body);
         let grenRequest = __HttpServer_toRequest({
-          __$urlProtocol: url.protocol,
-          __$urlHost: url.hostname,
-          __$urlPort: url.port,
-          __$urlPath: url.pathname,
-          __$urlQuery: url.search,
-          __$urlFragment: url.hash,
+          __$url: url.href,
           __$headers: request.rawHeaders,
           __$method: request.method,
           __$body: new DataView(

--- a/src/HttpServer.gren
+++ b/src/HttpServer.gren
@@ -162,54 +162,34 @@ methodToString method =
 This is only used internally.
 -}
 toRequest :
-    { urlProtocol : String
-    , urlHost : String
-    , urlPort : String
-    , urlPath : String
-    , urlQuery : String
-    , urlFragment : String
+    { url : String
     , headers : Array String
     , method : String
     , body : Bytes
     }
     -> Request
 toRequest 
-    { urlProtocol
-    , urlHost
-    , urlPort
-    , urlPath
-    , urlQuery
-    , urlFragment
+    { url
     , headers
     , method
     , body 
     } =
     { method = toMethod method
     , body = body
+    , url = 
+        Url.fromString url
+            |> Maybe.withDefault
+                { protocol = Http
+                , port_ = Nothing
+                , host = ""
+                , path = ""
+                , query = Nothing
+                , fragment = Nothing
+                }
     , headers =
         headers
             |> arrayPairs
             |> dictFromPairs
-    , url =
-        { protocol = 
-            if urlProtocol == "https:" then
-                Https
-            else
-                Http
-        , host = urlHost
-        , path = urlPath
-        , port_ = String.toInt urlPort
-        , query = 
-            if urlQuery == "" then
-                Nothing
-            else
-                Just urlQuery
-        , fragment =
-            if urlFragment == "" then
-                Nothing
-            else
-                Just urlFragment
-        }
     }
 
 
@@ -266,7 +246,7 @@ requestInfo req =
                 UNKNOWN m ->
                     "UNKNOWN(" ++ m ++ ")"
     in
-    method ++ " " ++ req.url.path
+    method ++ " " ++ (Url.toString req.url)
 
 
 toMethod : String -> Method


### PR DESCRIPTION
There's slight differences in how node and gren parse URLs. This moves the parsing logic into Gren where it should be.

Fixes https://github.com/gren-lang/node/issues/29