### PR TITLE
Allow child process spawned via `Task.spawn` to be cleaned up

### DIFF
--- a/src/Gren/Kernel/ChildProcess.js
+++ b/src/Gren/Kernel/ChildProcess.js
@@ -24,7 +24,7 @@ var _ChildProcess_run = function (options) {
     var env = options.__$environmentVariables;
     var shell = options.__$shell;
 
-    childProcess.execFile(
+    var subProc = childProcess.execFile(
       options.__$program,
       options.__$arguments,
       {
@@ -86,6 +86,10 @@ var _ChildProcess_run = function (options) {
         }
       },
     );
+
+    return () => {
+      subProc.kill();
+    };
   });
 };
 


### PR DESCRIPTION
While the full `ChildProcess.spawn` gives a lot more control over the lifecycle of a child process, this allows the simple version spawned via a `Task` to be shut down with `Process.kill`.