### PR TITLE
Refactor Sqlite api for running multiple statements

### DIFF
--- a/integration-tests/sqlite/src/Main.gren
+++ b/integration-tests/sqlite/src/Main.gren
@@ -134,6 +134,48 @@ tests fsPerm =
                         test "summary.changes is 1 (only reports from last execution)" <| \_ ->
                             Expect.equal 1 friendSum.changes
                      ]
+        , await "Open db for executeAll tests" createTestDb <| \db ->
+            let
+                statements =
+                    [ { statement = "INSERT INTO people (name, role) VALUES (:name, :role)"
+                      , parameters =
+                            [ Encode.string "name" robin.name
+                            , Encode.string "role" robin.role
+                            ]
+                      }
+                    , { statement = "INSERT INTO people (name, role) VALUES (:name, :role)"
+                      , parameters =
+                            [ Encode.string "name" justin.name
+                            , Encode.string "role" justin.role
+                            ]
+                      }
+                    , { statement =
+                            """
+                            INSERT INTO friends (person_a, person_b)
+                            SELECT a.id, b.id
+                            FROM people a, people b
+                            WHERE a.name = :personA AND b.name = :personB
+                            """
+                      , parameters =
+                            [ Encode.string "personA" robin.name
+                            , Encode.string "personB" justin.name
+                            ]
+                      }
+                    ]
+            in
+            await "Execute multiple different statements" (Sqlite.executeAll db statements) <| \summaries ->
+                concat
+                    [ test "Returns a summary per statement" <| \_ ->
+                        Expect.equal 3 (Array.length summaries)
+                    , await "Read all people from db" (Sqlite.getAll db allPeopleQ) <| \fromDb ->
+                        test "Both people were inserted" <| \_ ->
+                            Expect.equalArrays
+                                (Array.sortBy .name people)
+                                (Array.sortBy .name fromDb)
+                    , await "Read friends from db" (Sqlite.getOne db friendshipQ) <| \friendship ->
+                        test "Friendship was created" <| \_ ->
+                            Expect.equal { personA = robin.name, personB = justin.name } friendship
+                    ]
         , await "Open db for field type tests" (initializeFieldTypeDb fsPerm) <| \db ->
             await "Insert row with all field types" (insertAllFieldTypes allFieldTypes db) <| \_ ->
                 await "Read row with all field types" (Sqlite.getOne db allFieldTypesQ) <| \row ->
@@ -280,11 +322,28 @@ personByNameQ name =
 
 insertPeople : Array Person -> Sqlite.Database -> Task Sqlite.Error Sqlite.ExecutionSummary
 insertPeople persons db =
-    Sqlite.executeMany db
+    Sqlite.executeForEach db
         { statement = "INSERT INTO people (name, role) VALUES (:name, :role)"
         , parameters = personEncoder
         }
         persons
+
+
+friendshipQ : Sqlite.Query { personA : String, personB : String }
+friendshipQ =
+    { query =
+        """
+        SELECT a.name as person_a, b.name as person_b
+        FROM friends
+        JOIN people a ON friends.person_a = a.id
+        JOIN people b ON friends.person_b = b.id
+        """
+    , parameters = []
+    , rowDecoder =
+        Decode.string "person_a" <| \personA ->
+        Decode.string "person_b" <| \personB ->
+            Decode.succeed { personA = personA, personB = personB }
+    }
 
 
 allPeopleQ : Sqlite.Query Person
@@ -501,7 +560,7 @@ initializeTimeDb fsPerm =
 
 insertTimes : Array Time.Posix -> Sqlite.Database -> Task Sqlite.Error Sqlite.ExecutionSummary
 insertTimes times db =
-    Sqlite.executeMany db
+    Sqlite.executeForEach db
         { statement = "INSERT INTO times (t) VALUES (:t)"
         , parameters = \t -> [ Encode.timeWithMillis "t" t ]
         }

--- a/src/Sqlite.gren
+++ b/src/Sqlite.gren
@@ -129,7 +129,7 @@ execute :
        }
     -> Task Error ExecutionSummary
 execute db { statement, parameters } =
-    executeMany
+    executeForEach
         db
         { statement = statement
         , parameters = (\_ -> parameters)
@@ -137,14 +137,27 @@ execute db { statement, parameters } =
         [{}]
 
 
-executeMany :
+executeAll :
+    Database
+    -> Array
+        { statement : String
+        , parameters : Array Sqlite.Encode.Value
+        }
+    -> Task Error (Array ExecutionSummary)
+executeAll db statements =
+    statements
+        |> Array.map (execute db)
+        |> Task.sequence
+
+
+executeForEach :
     Database
     -> { statement : String
        , parameters : value -> Array Sqlite.Encode.Value
        }
     -> Array value
     -> Task Error ExecutionSummary
-executeMany db stmt vals =
+executeForEach db stmt vals =
     Gren.Kernel.Sqlite.executeMany stmt vals db
 
 

--- a/src/Sqlite.gren
+++ b/src/Sqlite.gren
@@ -111,6 +111,12 @@ getAll db query =
 -- EXECUTIONS
 
 
+type alias Statement =
+    { statement : String
+    , parameters : Array Sqlite.Encode.Value
+    }
+
+
 {-| A summary of how an execution changed the database.
 
     * `changes` - how many rows were inserted/updated/removed
@@ -122,12 +128,7 @@ type alias ExecutionSummary =
     }
 
 
-execute :
-    Database
-    -> { statement : String
-       , parameters : Array Sqlite.Encode.Value
-       }
-    -> Task Error ExecutionSummary
+execute : Database -> Statement -> Task Error ExecutionSummary
 execute db { statement, parameters } =
     executeForEach
         db
@@ -137,13 +138,7 @@ execute db { statement, parameters } =
         [{}]
 
 
-executeAll :
-    Database
-    -> Array
-        { statement : String
-        , parameters : Array Sqlite.Encode.Value
-        }
-    -> Task Error (Array ExecutionSummary)
+executeAll : Database -> Array Statement -> Task Error (Array ExecutionSummary)
 executeAll db statements =
     statements
         |> Array.map (execute db)


### PR DESCRIPTION
Adds `executeAll` to run multiple, independent statements, and renames `executeMany` to `executeForEach` to make the distinction clear.