### PR TITLE
Improve Sqlite constraint error types.

### DIFF
--- a/integration-tests/sqlite/src/Main.gren
+++ b/integration-tests/sqlite/src/Main.gren
@@ -131,8 +131,18 @@ tests fsPerm =
                         test "Right error type" <| \_ ->
                             Expect.equal (Sqlite.MultipleResultsError 2) err
                     , await "Define friends" (defineFriends robin.name justin.name db) <| \friendSum ->
-                        test "summary.changes is 1 (only reports from last execution)" <| \_ ->
-                            Expect.equal 1 friendSum.changes
+                        concat
+                            [ test "summary.changes is 1 (only reports from last execution)" <| \_ ->
+                                Expect.equal 1 friendSum.changes
+                            , awaitError "Define same friends again" (defineFriends robin.name justin.name db) <| \err ->
+                                test "Fails due to unique constraint" <| \_ ->
+                                    when err is
+                                        Sqlite.UniqueConstraintError _ ->
+                                            Expect.pass
+
+                                        _ ->
+                                            Expect.fail ("Expected UniqueConstraintError, but got: " ++ Sqlite.errorToString err)
+                            ]
                      ]
         , await "Open db for executeAll tests" createTestDb <| \db ->
             let

--- a/integration-tests/sqlite/src/Main.gren
+++ b/integration-tests/sqlite/src/Main.gren
@@ -57,7 +57,7 @@ tests fsPerm =
                 , awaitError "Define friends" (defineFriendsById 1 2 db) <| \err ->
                     test "Fails due to foreign key constraints" <| \_ ->
                         when err is
-                            Sqlite.ConstraintError message ->
+                            Sqlite.ForeignKeyError message ->
                                 if String.contains "foreign key" (String.toLower message) then
                                     Expect.pass
 

--- a/src/Gren/Kernel/Sqlite.js
+++ b/src/Gren/Kernel/Sqlite.js
@@ -1,6 +1,6 @@
 /*
 
-import Sqlite exposing (GenericError, ConstraintError, DecodingError)
+import Sqlite exposing (GenericError, ForeignKeyError, UniqueConstraintError, DecodingError)
 import Gren.Kernel.FilePath exposing (toString)
 import Gren.Kernel.Scheduler exposing (binding, succeed, fail)
 import Gren.Kernel.Json exposing (wrap, unwrap)
@@ -122,7 +122,13 @@ var _Sqlite_executeScript = F2(function (script, db) {
 var _Sqlite_constructError = function (e) {
   if (e.errcode === 787) {
     return __Scheduler_fail(
-      __Sqlite_ConstraintError(e.message)
+      __Sqlite_ForeignKeyError(e.message)
+    );
+  }
+
+  if (e.errcode === 2067) {
+    return __Scheduler_fail(
+      __Sqlite_UniqueConstraintError(e.message)
     );
   }
 

--- a/src/Sqlite.gren
+++ b/src/Sqlite.gren
@@ -191,7 +191,8 @@ type Error
     = GenericError String
     | NoResultsError
     | MultipleResultsError Int
-    | ConstraintError String
+    | ForeignKeyError String
+    | UniqueConstraintError String
     | DecodingError Decode.Error
 
 
@@ -207,8 +208,11 @@ errorToString error =
         MultipleResultsError n ->
             "Expected one result but got " ++ String.fromInt n
 
-        ConstraintError s ->
-            "Constraint error: " ++ s
+        ForeignKeyError s ->
+            "Foreign key error: " ++ s
+
+        UniqueConstraintError s ->
+            "Unique constraint error: " ++ s
 
         DecodingError e ->
             "Error decoding results: " ++ Decode.errorToString e


### PR DESCRIPTION
Code 787 is specifically a foreign key constraint error, so rename that type to be more specific.

Also add a unique constraint error since that is a common and likely expected error case. (I am explicitly checking for this in a couple of the new registry integration tests)

See https://sqlite.org/rescode.html