### PR TITLE
Unify open and openInMemory with Location type

### DIFF
--- a/integration-tests/sqlite/src/Main.gren
+++ b/integration-tests/sqlite/src/Main.gren
@@ -241,13 +241,13 @@ people = [ robin, justin ]
 
 initializeDb : FileSystem.Permission -> Task Sqlite.Error Sqlite.Database
 initializeDb fsPerm =
-    Sqlite.openInMemory fsPerm Sqlite.defaultOptions
+    Sqlite.open fsPerm Sqlite.defaultOptions Sqlite.Memory
         |> Task.andThen execDbSchema
 
 
 initializePhysicalDb : FileSystem.Permission -> Task Sqlite.Error Sqlite.Database
 initializePhysicalDb fsPerm =
-    Sqlite.open fsPerm Sqlite.defaultOptions diskDbPath
+    Sqlite.open fsPerm Sqlite.defaultOptions (Sqlite.File diskDbPath)
         |> Task.andThen execDbSchema
 
 
@@ -434,7 +434,7 @@ allFieldTypes =
 
 initializeFieldTypeDb : FileSystem.Permission -> Task Sqlite.Error Sqlite.Database
 initializeFieldTypeDb fsPerm =
-    Sqlite.openInMemory fsPerm Sqlite.defaultOptions
+    Sqlite.open fsPerm Sqlite.defaultOptions Sqlite.Memory
         |> Task.andThen
             (\db ->
                 Sqlite.executeScript db
@@ -556,7 +556,7 @@ allFieldTypesQ =
 
 initializeTimeDb : FileSystem.Permission -> Task Sqlite.Error Sqlite.Database
 initializeTimeDb fsPerm =
-    Sqlite.openInMemory fsPerm Sqlite.defaultOptions
+    Sqlite.open fsPerm Sqlite.defaultOptions Sqlite.Memory
         |> Task.andThen
             (\db ->
                 Sqlite.executeScript db

--- a/src/Sqlite.gren
+++ b/src/Sqlite.gren
@@ -19,6 +19,11 @@ type Database
     = Database
 
 
+type Location
+    = Memory
+    | File Path
+
+
 {-| When opening the database, you can define a set of restrictions that apply for all
 queries and statements executed.
 
@@ -44,14 +49,14 @@ defaultOptions =
     }
 
 
-open : FileSystem.Permission -> Options -> Path -> Task Error Database
-open _ opts path =
-    Gren.Kernel.Sqlite.open opts path
+open : FileSystem.Permission -> Options -> Location -> Task Error Database
+open _ opts location =
+    when location is
+        File path ->
+            Gren.Kernel.Sqlite.open opts path
 
-
-openInMemory : FileSystem.Permission -> Options -> Task x Database
-openInMemory _ opts =
-    Gren.Kernel.Sqlite.openInMemory opts
+        Memory ->
+            Gren.Kernel.Sqlite.openInMemory opts
 
 
 close : Database -> Task Error {}


### PR DESCRIPTION
Closes https://github.com/gren-lang/node/issues/46

Thoughts on adding a ConnectionString variant? It could just be a pass-thru to DatabaseSync. That would make it a lot easier to configure the registry with environment variables for deployment. I'm torn because that's a pretty raw approach, and a true Uri option would be better, but it doesn't look like node's sqlite supports sqlite's uri config.