### PR TITLE
Use iterators for `getOne` and `getMaybeOne` functions

### DIFF
--- a/src/Gren/Kernel/Sqlite.js
+++ b/src/Gren/Kernel/Sqlite.js
@@ -1,6 +1,6 @@
 /*
 
-import Sqlite exposing (GenericError, ForeignKeyError, UniqueConstraintError, DecodingError)
+import Sqlite exposing (GenericError, ForeignKeyError, UniqueConstraintError, DecodingError, MultipleResultsError)
 import Gren.Kernel.FilePath exposing (toString)
 import Gren.Kernel.Scheduler exposing (binding, succeed, fail)
 import Gren.Kernel.Json exposing (wrap, unwrap)
@@ -8,6 +8,7 @@ import Json.Decode as Decode exposing (decodeValue)
 import Result exposing (isOk)
 import Sqlite.Encode as SqliteEncode exposing (toJson)
 import Sqlite.Decode as SqliteDecode exposing (toJson)
+import Maybe exposing (Just, Nothing)
 
 */
 
@@ -77,6 +78,48 @@ var _Sqlite_getAll = F2(function (query, db) {
 
       callback(__Scheduler_succeed(results));
     } catch (e) {
+      callback(_Sqlite_constructError(e));
+    }
+  });
+});
+
+var _Sqlite_getMaybeOne = F2(function (query, db) {
+  return __Scheduler_binding(function (callback) {
+    try {
+      const prepped = db.prepare(query.__$query);
+      const params = __Json_unwrap(__SqliteEncode_toJson(query.__$parameters));
+      const rowDecoder = __SqliteDecode_toJson(query.__$rowDecoder);
+      const iterator = prepped.iterate(params);
+
+      const value = iterator.next().value;
+
+      if (!value) {
+        return callback(__Scheduler_succeed(__Maybe_Nothing))
+      }
+
+      if (!iterator.next().done) {
+        var count = 2;
+        for (const value of iterator) {
+            count++;
+        }
+        return callback(__Scheduler_fail(__Sqlite_MultipleResultsError(count)))
+      }
+
+      const result = A2(
+        __Decode_decodeValue,
+        rowDecoder,
+        _Json_wrap(value),
+      );
+
+      if (__Result_isOk(result)) {
+        callback(__Scheduler_succeed(__Maybe_Just(result.a)))
+      } else {
+        return callback(
+          __Scheduler_fail(__Sqlite_DecodingError(result.a)),
+        );
+      }
+    }
+    catch (e) {
       callback(_Sqlite_constructError(e));
     }
   });

--- a/src/Gren/Kernel/Sqlite.js
+++ b/src/Gren/Kernel/Sqlite.js
@@ -94,32 +94,25 @@ var _Sqlite_getMaybeOne = F2(function (query, db) {
       const value = iterator.next().value;
 
       if (!value) {
-        return callback(__Scheduler_succeed(__Maybe_Nothing))
+        return callback(__Scheduler_succeed(__Maybe_Nothing));
       }
 
       if (!iterator.next().done) {
         var count = 2;
         for (const value of iterator) {
-            count++;
+          count++;
         }
-        return callback(__Scheduler_fail(__Sqlite_MultipleResultsError(count)))
+        return callback(__Scheduler_fail(__Sqlite_MultipleResultsError(count)));
       }
 
-      const result = A2(
-        __Decode_decodeValue,
-        rowDecoder,
-        _Json_wrap(value),
-      );
+      const result = A2(__Decode_decodeValue, rowDecoder, _Json_wrap(value));
 
       if (__Result_isOk(result)) {
-        callback(__Scheduler_succeed(__Maybe_Just(result.a)))
+        callback(__Scheduler_succeed(__Maybe_Just(result.a)));
       } else {
-        return callback(
-          __Scheduler_fail(__Sqlite_DecodingError(result.a)),
-        );
+        return callback(__Scheduler_fail(__Sqlite_DecodingError(result.a)));
       }
-    }
-    catch (e) {
+    } catch (e) {
       callback(_Sqlite_constructError(e));
     }
   });

--- a/src/Sqlite.gren
+++ b/src/Sqlite.gren
@@ -76,36 +76,21 @@ type alias Query value =
 
 getOne : Database -> Query value -> Task Error value
 getOne db query =
-    getAll db query
+    Gren.Kernel.Sqlite.getMaybeOne query db
         |> Task.andThen
             (\results ->
                 when results is
-                    [] ->
+                    Nothing ->
                         Task.fail NoResultsError
 
-                    [ value ] ->
+                    Just value ->
                         Task.succeed value
-
-                    _ ->
-                        Task.fail (MultipleResultsError (Array.length results))
             )
 
 
 getMaybeOne : Database -> Query value -> Task Error (Maybe value)
 getMaybeOne db query =
-    getAll db query
-        |> Task.andThen
-            (\results ->
-                when results is
-                    [] ->
-                        Task.succeed Nothing
-
-                    [ value ] ->
-                        Task.succeed (Just value)
-
-                    _ ->
-                        Task.fail (MultipleResultsError (Array.length results))
-            )
+    Gren.Kernel.Sqlite.getMaybeOne query db
         
 
 getAll : Database -> Query value -> Task Error (Array value)


### PR DESCRIPTION
Fixes #44

Use iterators to avoid getting many rows from the database when you only want one. Applies to `getOne` and `getMaybeOne` functions. Preserves count of returned rows when failing due to multiple results by looping through the iterator. Nothing else remarkable about the code!

All tests are passing for me locally, with no new tests added.