### PR TITLE
Implement `Sqlite.backup`

### DIFF
--- a/integration-tests/sqlite/src/Main.gren
+++ b/integration-tests/sqlite/src/Main.gren
@@ -73,6 +73,44 @@ tests fsPerm =
                     test "Works" <| \_ ->
                         Expect.pass
                 ]
+        , await "Create database for backup testing" createTestDb <| \db ->
+            let
+                backupDbPath =
+                    Path.fromPosixString ".backup.db"
+
+                slowBackupDbPath =
+                    Path.fromPosixString ".backup-slow.db"
+            in
+            concat
+                [ await "Insert a person into the created database" (insertPerson joey db) <| \_ ->
+                    concat
+                    [ await "Backup the database"
+                        (Sqlite.backup fsPerm backupDbPath db |> Sqlite.runBackup) <| \_ ->
+                            await "Open the newly backed up database"
+                                (Sqlite.open fsPerm Sqlite.defaultOptions (Sqlite.File backupDbPath)) <| \backupDb ->
+                                    await "Get the person from the backup database" 
+                                        (Sqlite.getOne backupDb (personByNameQ joey.name))  <| \backupPerson ->
+                                            await "Also get the person from the original database" 
+                                                (Sqlite.getOne backupDb (personByNameQ joey.name)) <| \originalPerson ->
+                                                    concat
+                                                        [ test "Name is the same in original and backup database" <| \_ ->
+                                                            Expect.equal backupPerson.name originalPerson.name
+                                                        , test "Role is the same in original and backup database" <| \_ ->
+                                                            Expect.equal backupPerson.role originalPerson.role
+                                                        , await "Remove from disk" (FileSystem.remove fsPerm { recursive = False } backupDbPath) <| \_ ->
+                                                                test "Worked" <| \_ ->
+                                                                    Expect.pass
+                                                        ]
+                    , await "Backup the database to a different file with a smaller page count" 
+                        (Sqlite.backup fsPerm slowBackupDbPath db 
+                            |> Sqlite.withBackupPageRate 1
+                            |> Sqlite.runBackup
+                        ) <| \_ ->
+                            await "Remove from disk" (FileSystem.remove fsPerm { recursive = False } slowBackupDbPath) <| \_ ->
+                                test "Worked" <| \_ ->
+                                    Expect.pass
+                    ]
+                ]
         , await "Open physical database" (initializePhysicalDb fsPerm) <| \db ->
             await "Can be closed" (Sqlite.close db) <| \_ ->
                 await "Remove from disk" (FileSystem.remove fsPerm { recursive = False } diskDbPath) <| \_ ->
@@ -255,6 +293,13 @@ justin : Person
 justin =
     { name = "Justin"
     , role = "Core developer"
+    }
+
+
+joey : Person
+joey =
+    { name = "Joey"
+    , role = "Contributor"
     }
 
 

--- a/integration-tests/sqlite/src/Main.gren
+++ b/integration-tests/sqlite/src/Main.gren
@@ -91,7 +91,7 @@ tests fsPerm =
                                     await "Get the person from the backup database" 
                                         (Sqlite.getOne backupDb (personByNameQ joey.name))  <| \backupPerson ->
                                             await "Also get the person from the original database" 
-                                                (Sqlite.getOne backupDb (personByNameQ joey.name)) <| \originalPerson ->
+                                                (Sqlite.getOne db (personByNameQ joey.name)) <| \originalPerson ->
                                                     concat
                                                         [ test "Name is the same in original and backup database" <| \_ ->
                                                             Expect.equal backupPerson.name originalPerson.name

--- a/src/Gren/Kernel/Sqlite.js
+++ b/src/Gren/Kernel/Sqlite.js
@@ -52,6 +52,27 @@ var _Sqlite_close = function (db) {
   });
 };
 
+var _Sqlite_backup = F3(function (destination, pages, db) {
+  return __Scheduler_binding(function (callback) {
+    try {
+      sqlite
+        .backup(db, destination, {
+          source: "main",
+          target: "main",
+          rate: pages,
+        })
+        .then(function (res) {
+          callback(__Scheduler_succeed({}));
+        })
+        .catch(function (e) {
+          callback(_Sqlite_constructError(e));
+        });
+    } catch (e) {
+      callback(_Sqlite_constructError(e));
+    }
+  });
+});
+
 var _Sqlite_foldl = F4(function (query, db, func, acc) {
   return __Scheduler_binding(function (callback) {
     try {

--- a/src/Gren/Kernel/Sqlite.js
+++ b/src/Gren/Kernel/Sqlite.js
@@ -56,7 +56,7 @@ var _Sqlite_backup = F3(function (destination, pages, db) {
   return __Scheduler_binding(function (callback) {
     try {
       sqlite
-        .backup(db, destination, {
+        .backup(db, _FilePath_toString(destination), {
           source: "main",
           target: "main",
           rate: pages,

--- a/src/Sqlite.gren
+++ b/src/Sqlite.gren
@@ -94,7 +94,7 @@ withBackupPageRate pages (Backup record) =
 
 runBackup : Backup -> Task Error {}
 runBackup (Backup { destination, pages, db }) =
-    Gren.Kernel.Sqlite.backup (FileSystem.Path.toPosixString destination) pages db
+    Gren.Kernel.Sqlite.backup destination pages db
 
 
 

--- a/src/Sqlite.gren
+++ b/src/Sqlite.gren
@@ -65,6 +65,39 @@ close =
     Gren.Kernel.Sqlite.close
 
 
+
+-- Backup
+
+
+type Backup
+    = Backup
+        { destination : Path
+        , pages : Int
+        , db : Database
+        }
+
+
+
+backup : FileSystem.Permission -> Path -> Database -> Backup
+backup _ path db =
+    Backup
+        { destination = path
+        , pages = 100
+        , db = db
+        }
+
+
+withBackupPageRate : Int -> Backup -> Backup
+withBackupPageRate pages (Backup record) =
+    Backup { record | pages = pages }
+
+
+runBackup : Backup -> Task Error {}
+runBackup (Backup { destination, pages, db }) =
+    Gren.Kernel.Sqlite.backup (FileSystem.Path.toPosixString destination) pages db
+
+
+
 -- Query
 
 


### PR DESCRIPTION
- Simple implementation and integration tests for the `backup` SQLite function
- Using a builder pattern to allow specifying the rate of backup, allowing backup config to live in a variable separate from actually running it, and leave open any other future configuration options that we might want to add. 
- What isn't here: I tried to hook into the [`progress` functionality](https://nodejs.org/docs/latest-v22.x/api/sqlite.html#sqlitebackupsourcedb-destination-options) provided by the SQLite node module, but ran into a lot of issues trying to get it to work with Gren streams. It's purely additive, though, and doesn't block the essential functionality that is working in this PR. We can add it in a later release, I think.

Fixes #54 